### PR TITLE
Fix #6: Overlap-Based Combat is Fragile

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -29,6 +29,8 @@ export class GameScene extends Phaser.Scene {
   private isAttacking = false;
   private playerHealth = 100;
   private playerMaxHealth = 100;
+  private invincibleUntil = 0; // timestamp when i-frames expire
+  private isInvincibleBlinking = false;
 
   // Parallax layers
   private bgLayer1!: Phaser.GameObjects.TileSprite;
@@ -54,6 +56,7 @@ export class GameScene extends Phaser.Scene {
   private readonly JUMP_VELOCITY = -380;
   private readonly PLAYER_SCALE = 2;
   private readonly ENEMY_SCALE = 1.8;
+  private readonly INVINCIBILITY_DURATION = 1000; // ms of i-frames after taking damage
 
   constructor() {
     super({ key: 'GameScene' });
@@ -210,6 +213,7 @@ export class GameScene extends Phaser.Scene {
     this.updateParallax();
     this.updatePlayer();
     this.updateEnemies(time);
+    this.updateInvincibilityBlink(time);
     this.drawHealthBar();
   }
 
@@ -219,6 +223,27 @@ export class GameScene extends Phaser.Scene {
     this.bgLayer1.tilePositionX = camX * 0.1;
     this.bgLayer2.tilePositionX = camX * 0.3;
     this.bgLayer3.tilePositionX = camX * 0.6;
+  }
+
+  // ---- INVINCIBILITY BLINK ----
+  private updateInvincibilityBlink(time: number): void {
+    if (time < this.invincibleUntil) {
+      // Start blink tween when invincibility begins
+      if (!this.isInvincibleBlinking) {
+        this.isInvincibleBlinking = true;
+        this.tweens.add({
+          targets: this.player,
+          alpha: 0.3,
+          duration: 80,
+          yoyo: true,
+          repeat: Math.ceil(this.INVINCIBILITY_DURATION / 160),
+          onComplete: () => {
+            this.player.setAlpha(1);
+            this.isInvincibleBlinking = false;
+          },
+        });
+      }
+    }
   }
 
   // ---- PLAYER UPDATE ----
@@ -368,6 +393,9 @@ export class GameScene extends Phaser.Scene {
     const ai = enemy.getData('ai') as EnemyData;
     if (ai.isDead) return;
 
+    // Check invincibility frames - skip damage if player is still invincible
+    if (this.time.now < this.invincibleUntil) return;
+
     // Enemy attacks player when in attack state
     if (ai.isAttacking && this.playerState !== 'shield' && this.playerState !== 'damage') {
       this.playerTakeDamage(10, enemy);
@@ -423,6 +451,9 @@ export class GameScene extends Phaser.Scene {
   }
 
   private playerTakeDamage(amount: number, source: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody): void {
+    // Set invincibility frames - player cannot take damage again until invincibleUntil passes
+    this.invincibleUntil = this.time.now + this.INVINCIBILITY_DURATION;
+
     this.playerHealth = Math.max(0, this.playerHealth - amount);
 
     // Knockback
@@ -430,7 +461,7 @@ export class GameScene extends Phaser.Scene {
     this.player.setVelocityX(dir * 200);
     this.player.setVelocityY(-120);
 
-    // Flash
+    // Flash red
     this.player.setTint(0xff4444);
     this.time.delayedCall(200, () => this.player.clearTint());
 
@@ -444,7 +475,10 @@ export class GameScene extends Phaser.Scene {
         this.playerState = 'death';
         this.player.play('player_death', true);
         this.player.body.enable = false;
-        this.time.delayedCall(2000, () => this.scene.restart());
+        this.time.delayedCall(2000, () => {
+          this.player.setAlpha(1);
+          this.scene.restart();
+        });
       }
     });
   }

--- a/verdant-leap.html
+++ b/verdant-leap.html
@@ -326,7 +326,7 @@ var GameScene = new Phaser.Class({
         // ── Player state ──
         this.score        = 0;
         this.hp           = P.HP;
-        this.invTimer     = 0;
+        this.invincibleUntil = 0;
         this.jumpCount    = 0;
         this.coyoteTimer  = 0;
         this.jumpBuf      = 0;
@@ -660,7 +660,7 @@ var GameScene = new Phaser.Class({
         }
 
         // Enemy damages player
-        if(this.invTimer > 0) return;
+        if(this.time.now < this.invincibleUntil) return;
 
         // Ground enemies only damage in attack state
         if(enemy.eData.type === 'ground' && enemy.eData.state !== 'attack') return;
@@ -706,10 +706,10 @@ var GameScene = new Phaser.Class({
 
     // ════════════ DAMAGE PLAYER ════════════
     damagePlayer: function(enemy){
-        if(this.invTimer > 0 || this.gameOver) return;
+        if(this.time.now < this.invincibleUntil || this.gameOver) return;
         this.hp--;
         this.updateHearts();
-        this.invTimer = P.INV_DUR;
+        this.invincibleUntil = this.time.now + P.INV_DUR * 1000;
 
         var dir = (this.player.x < enemy.x) ? -1 : 1;
         this.player.body.velocity.x = dir * P.KB_X;
@@ -1179,13 +1179,10 @@ var GameScene = new Phaser.Class({
         }
 
         // ── Invincibility blink ──
-        if(this.invTimer > 0){
-            this.invTimer -= dt;
+        if(this.time.now < this.invincibleUntil){
             pl.setAlpha(Math.sin(time * 0.02) > 0 ? 1 : 0.3);
-            if(this.invTimer <= 0){
-                pl.setAlpha(1);
-                this.invTimer = 0;
-            }
+        } else if(pl.alpha < 1){
+            pl.setAlpha(1);
         }
 
         // ── Landing squash ──


### PR DESCRIPTION
Resolves #6

## Problem
Combat uses `physics.add.overlap()` which fires every frame the player and enemy overlap. Even with the `isAttacking` guard on the enemy side, the player's `handleCombat` callback can fire multiple times per contact. There was no invincibility frame system for the player — only a brief state lock via `isAttacking = true`. This meant:

- Player could take damage multiple times from a single enemy attack
- No i-frames after taking a hit

## Fix
Added an `invincibleUntil: number` timestamp system:

1. **New properties**: `invincibleUntil` (timestamp) and `isInvincibleBlinking` (visual guard) on `GameScene`
2. **New constant**: `INVINCIBILITY_DURATION = 1000` (1 second of invincibility after taking damage)
3. **`handleCombat()` guard**: Returns early if `this.time.now < this.invincibleUntil`, preventing multiple damage calls during overlap
4. **`playerTakeDamage()` update**: Sets `invincibleUntil = this.time.now + INVINCIBILITY_DURATION` on hit
5. **Visual feedback**: Added `updateInvincibilityBlink()` method that creates an alpha-toggling tween so the player blinks during i-frames
6. **Death cleanup**: Reset alpha to 1 before scene restart to prevent stuck blink state
